### PR TITLE
chore: add ptt-ti with maintain permission

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -16,6 +16,8 @@ repository:
 teams:
   - name: architecture-support
     permission: admin
+  - name: ptt-ti
+    permission: maintain
 
 branches:
   - name: master


### PR DESCRIPTION
permission for telus/ptt-ti keeps getting removed by bots